### PR TITLE
fix: treat all login validation failures as invalid credentials

### DIFF
--- a/mvvm/src/app/(auth)/actions.ts
+++ b/mvvm/src/app/(auth)/actions.ts
@@ -60,11 +60,12 @@ export const login = async (
 
     return { status: "success" };
   } catch (error: any) {
+    // Zod validation failures on the login form (bad email format, short password)
+    // should surface as invalid credentials, not a validation error — the user
+    // doesn't need to know why their login failed at that level of detail.
     if (error instanceof z.ZodError) {
-      return { status: "invalid_data" };
+      return { status: "failed" };
     }
-    // Auth.js throws CredentialsSignin on bad credentials — check all possible
-    // shapes it might come in, log anything that isn't a credentials error
     const isCredentialsError =
       error?.type === "CredentialsSignin" ||
       error?.name === "CredentialsSignin" ||


### PR DESCRIPTION
Zod errors on the login form (bad email format, password too short) were returning invalid_data and showing 'Please enter valid inputs!' — which leaks implementation detail to the user. All login failures, including format errors, now return failed and show 'Invalid credentials!'