### PR TITLE
feat: implement account email verification with 48h expiry and cleanu…

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -50,6 +50,10 @@ model User {
   location    String?
   isVerified  Boolean @default(false)
 
+  // Email verification
+  verificationToken       String?
+  verificationTokenExpiry DateTime?
+
   // Security
   twoFactorEnabled  Boolean @default(false)
 
@@ -73,7 +77,7 @@ model User {
   likes                  Like[]
   receivedNotifications Notification[] @relation("NotificationRecipient")
   sentNotifications     Notification[] @relation("NotificationActor")
-  sessions              UserSession[] 
+  sessions              UserSession[]
 }
 
 

--- a/backend/src/controllers/usersController.ts
+++ b/backend/src/controllers/usersController.ts
@@ -16,8 +16,15 @@ import {
   createUserSession,
   createPasswordResetToken,
   consumePasswordResetToken,
+  createVerificationToken,
+  verifyAccountToken,
+  deleteExpiredUnverifiedUsers,
 } from "../services/usersService.js";
-import { passwordResetEmail } from "../services/contactService.js";
+import {
+  passwordResetEmail,
+  verificationEmail,
+  welcomeNewUserEmail,
+} from "../services/contactService.js";
 import { userSchema } from "../schemas/validation.js";
 import { ZodError } from "zod";
 import { UUID } from "crypto";
@@ -29,6 +36,21 @@ const JWT_SECRET = process.env.NEXT_AUTH_SECRET;
 if (!JWT_SECRET) {
   throw new Error("NEXTAUTH_SECRET is not defined in environment variables");
 }
+
+// ── Cleanup job: runs every hour, deletes expired unverified accounts ──────────
+const CLEANUP_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
+setInterval(async () => {
+  try {
+    await deleteExpiredUnverifiedUsers();
+  } catch (err) {
+    console.error("Cleanup job error:", err);
+  }
+}, CLEANUP_INTERVAL_MS);
+
+// Run once immediately on server start
+deleteExpiredUnverifiedUsers().catch((err) =>
+  console.error("Initial cleanup error:", err),
+);
 
 // ================= GET =======================
 
@@ -47,7 +69,6 @@ export const getMeController = async (
   }
 };
 
-// GET /api/users/
 export const getAllUsersController = async (
   req: express.Request,
   res: express.Response,
@@ -61,7 +82,6 @@ export const getAllUsersController = async (
   }
 };
 
-// GET /api/users/email/:email
 export const getUserByEmailController = async (
   req: express.Request,
   res: express.Response,
@@ -84,7 +104,6 @@ export const getUserByEmailController = async (
   }
 };
 
-// GET /api/users/user/:username
 export const getUserByUsernameController = async (
   req: express.Request,
   res: express.Response,
@@ -222,6 +241,16 @@ export const createNewUserController = async (
 
     const newUser = await createUserService(validatedData);
 
+    // Generate verification token and send verification + welcome emails
+    const token = await createVerificationToken(newUser.id);
+    const verifyUrl = `${process.env.FRONTEND_URL}/verify-email?token=${token}`;
+
+    // Fire both emails concurrently — don't block the response
+    Promise.all([
+      verificationEmail(newUser.email, newUser.username, verifyUrl),
+      welcomeNewUserEmail(newUser.email, newUser.username),
+    ]).catch((err) => console.error("Error sending registration emails:", err));
+
     res.status(201).json(newUser);
   } catch (error) {
     console.error("User creation failed:", error);
@@ -251,7 +280,6 @@ export const loginUserController = async (
   }
 };
 
-// POST /api/users/forgot-password
 export const forgotPasswordController = async (
   req: express.Request,
   res: express.Response,
@@ -265,8 +293,6 @@ export const forgotPasswordController = async (
 
     const token = await createPasswordResetToken(email);
 
-    // Always return 200 regardless of whether the email exists —
-    // this prevents user enumeration attacks
     if (token) {
       const resetUrl = `${process.env.FRONTEND_URL}/reset-password?token=${token}`;
       await passwordResetEmail(email, resetUrl);
@@ -282,7 +308,6 @@ export const forgotPasswordController = async (
   }
 };
 
-// POST /api/users/reset-password
 export const resetPasswordController = async (
   req: express.Request,
   res: express.Response,
@@ -306,7 +331,28 @@ export const resetPasswordController = async (
   }
 };
 
-// ============================== DELETE ==================================
+export const verifyEmailController = async (
+  req: express.Request,
+  res: express.Response,
+) => {
+  try {
+    const { token } = req.body;
+    if (!token) {
+      res.status(400).json({ message: "Token is required" });
+      return;
+    }
+
+    await verifyAccountToken(token);
+    res.status(200).json({ message: "Email verified successfully" });
+  } catch (err: any) {
+    if (err.message === "INVALID_OR_EXPIRED_TOKEN") {
+      res.status(400).json({ message: "Invalid or expired verification token" });
+    } else {
+      console.error("Verify email error:", err);
+      res.status(500).json({ message: "Internal server error" });
+    }
+  }
+};
 
 export const deleteSessionController = async (
   req: AuthenticatedRequest,

--- a/backend/src/routes/user-routes.ts
+++ b/backend/src/routes/user-routes.ts
@@ -16,6 +16,7 @@ import {
   getUserSessionsController,
   forgotPasswordController,
   resetPasswordController,
+  verifyEmailController,
 } from "../controllers/usersController.js";
 import { verifyToken } from "../middleware.js";
 import multer from "multer";
@@ -23,55 +24,21 @@ import multer from "multer";
 const router = express.Router();
 const upload = multer({ dest: "avatars/" });
 
-// GET /api/users/email/:email
 router.get("/email/:email", getUserByEmailController);
-
-// GET /api/users/username/:username
 router.get("/username/:username", getUserByUsernameController);
-
-// Get all users
 router.get("/", getAllUsersController);
-
-// Get the user thats signed into the session
 router.get("/me", verifyToken, getMeController);
-
-// Retrieve all the users sessions
 router.get("/me/sessions", verifyToken, getUserSessionsController);
-
-// Update user profile
 router.patch("/me", verifyToken, updateUserController);
-
-// Update user password
 router.patch("/me/password", verifyToken, updateUserPassword);
-
-// Update user profile visibility
 router.patch("/me/privacy", verifyToken, updateUserVisibility);
-
-// Update user avatar
-router.patch(
-  "/me/avatar",
-  verifyToken,
-  upload.single("avatar"),
-  updateUserAvatar,
-);
-
-// Login user
+router.patch("/me/avatar", verifyToken, upload.single("avatar"), updateUserAvatar);
 router.post("/login", loginUserController);
-
-// Create new user
 router.post("/register", createNewUserController);
-
-// Request a password reset email
 router.post("/forgot-password", forgotPasswordController);
-
-// Consume reset token and set new password
 router.post("/reset-password", resetPasswordController);
-
+router.post("/verify-email", verifyEmailController);
 router.delete("/me/session/:sessionId", verifyToken, deleteSessionController);
-router.delete(
-  "/me/sessions/:sessionId",
-  verifyToken,
-  deleteAllOtherSessionsController,
-);
+router.delete("/me/sessions/:sessionId", verifyToken, deleteAllOtherSessionsController);
 
 export default router;

--- a/backend/src/services/contactService.ts
+++ b/backend/src/services/contactService.ts
@@ -21,6 +21,74 @@ export async function contactAdminEmail({ to, subject, html }: EmailParams) {
   }
 }
 
+export async function verificationEmail(
+  to: string,
+  username: string,
+  verifyUrl: string,
+) {
+  try {
+    const data = await resend.emails.send({
+      from: "The Blogging Photographer <noreply@blog.adkins.ninja>",
+      to,
+      subject: "Please verify your email — Adkins Ninja Blog",
+      html: `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Verify Your Email</title>
+</head>
+<body style="font-family: Arial, sans-serif; line-height: 1.6; color: #333;">
+  <div style="max-width: 600px; margin: 0 auto; padding: 24px;">
+
+    <h2 style="color: #92400e;">Welcome, ${username}! One small step to go 🎉</h2>
+
+    <p>We're so excited to have you join the Adkins Ninja Blog community! Before you dive in, we just need to confirm that this email address belongs to you.</p>
+
+    <p>Click the button below to verify your email and activate your account:</p>
+
+    <div style="text-align: center; margin: 32px 0;">
+      <a href="${verifyUrl}"
+        style="background-color: #92400e; color: #ffffff; padding: 14px 32px; text-decoration: none; border-radius: 6px; font-weight: bold; display: inline-block; font-size: 1rem;">
+        Verify My Email
+      </a>
+    </div>
+
+    <p>If the button above doesn't work, copy and paste this link into your browser:</p>
+    <p style="word-break: break-all; color: #92400e;">${verifyUrl}</p>
+
+    <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 32px 0;" />
+
+    <p style="color: #b45309;">
+      ⏳ <strong>Heads up:</strong> This verification link expires in <strong>48 hours</strong>.
+      If your account isn't verified within that time, it will be removed from our system and
+      you'll need to sign up again. We do this to keep our community safe and spam-free.
+    </p>
+
+    <hr style="border: none; border-top: 1px solid #e5e7eb; margin: 32px 0;" />
+
+    <p style="font-size: 0.85rem; color: #6b7280;">
+      If you didn't create an account, you can safely ignore this email — nothing will happen.
+      If you need help, visit our <a href="https://blog.adkins.ninja/contact" style="color: #92400e;">Contact Page</a>.
+    </p>
+
+    <p>We can't wait to see you around!<br>
+    <strong>The Adkins Ninja Blog Team</strong></p>
+  </div>
+</body>
+</html>
+      `,
+    });
+
+    console.log("Verification email sent:", data);
+    return data;
+  } catch (error) {
+    console.error("Verification email failed:", error);
+    throw error;
+  }
+}
+
 export async function welcomeNewUserEmail(to: string, username: string) {
   try {
     const data = await resend.emails.send({
@@ -28,7 +96,7 @@ export async function welcomeNewUserEmail(to: string, username: string) {
       to,
       subject: "Welcome to Adkins Ninja Blog",
       html: `
-    <!DOCTYPE html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <meta charset="UTF-8">
@@ -59,8 +127,7 @@ export async function welcomeNewUserEmail(to: string, username: string) {
   <!-- <p><strong>P.S.</strong> Don't forget to follow us on <a href="[Social Media Links]">Social Media</a> for the latest updates!</p> -->
 </body>
 </html>
-
-  `,
+      `,
     });
 
     console.log("Email sent:", data);

--- a/backend/src/services/usersService.ts
+++ b/backend/src/services/usersService.ts
@@ -34,7 +34,6 @@ const _findUserInDb = async (args: {
   return user;
 };
 
-// Find user by email
 export const findUserByEmail = async (email: string, include = false) => {
   let user;
   if (include)
@@ -52,7 +51,6 @@ export const findUserByEmail = async (email: string, include = false) => {
   return user;
 };
 
-// Find user by username
 export const findUserByUsername = async (username: string, include = false) => {
   let user;
   if (include)
@@ -70,7 +68,6 @@ export const findUserByUsername = async (username: string, include = false) => {
   return user;
 };
 
-// Find user by password reset token
 export const findUserByResetToken = async (token: string) => {
   return await db.user.findFirst({
     where: {
@@ -80,7 +77,15 @@ export const findUserByResetToken = async (token: string) => {
   });
 };
 
-// Find user by email
+export const findUserByVerificationToken = async (token: string) => {
+  return await db.user.findFirst({
+    where: {
+      verificationToken: token,
+      verificationTokenExpiry: { gt: new Date() },
+    },
+  });
+};
+
 export const getUserPasswordById = async (id: UUID) => {
   const user = await _findUserInDb({ where: { id } });
   return user?.password;
@@ -283,13 +288,12 @@ export const verifyPassword = async (
   return bcrypt.compare(plainPassword, hashedPassword);
 };
 
-// Generate a secure reset token and store it on the user (expires in 1 hour)
 export const createPasswordResetToken = async (email: string) => {
   const user = await findUserByEmail(email);
-  if (!user) return null; // Don't reveal whether the email exists
+  if (!user) return null;
 
   const token = crypto.randomBytes(32).toString("hex");
-  const expiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour from now
+  const expiry = new Date(Date.now() + 60 * 60 * 1000); // 1 hour
 
   await db.user.update({
     where: { email },
@@ -302,7 +306,6 @@ export const createPasswordResetToken = async (email: string) => {
   return token;
 };
 
-// Consume the reset token and update the password
 export const consumePasswordResetToken = async (
   token: string,
   newPassword: string,
@@ -320,4 +323,53 @@ export const consumePasswordResetToken = async (
       resetTokenExpiry: null,
     },
   });
+};
+
+// Generate a verification token for a new user (expires in 48 hours)
+export const createVerificationToken = async (userId: string) => {
+  const token = crypto.randomBytes(32).toString("hex");
+  const expiry = new Date(Date.now() + 48 * 60 * 60 * 1000); // 48 hours
+
+  await db.user.update({
+    where: { id: userId },
+    data: {
+      verificationToken: token,
+      verificationTokenExpiry: expiry,
+    },
+  });
+
+  return token;
+};
+
+// Consume the verification token and mark the user as verified
+export const verifyAccountToken = async (token: string) => {
+  const user = await findUserByVerificationToken(token);
+  if (!user) throw new Error("INVALID_OR_EXPIRED_TOKEN");
+
+  await db.user.update({
+    where: { id: user.id },
+    data: {
+      isVerified: true,
+      verificationToken: null,
+      verificationTokenExpiry: null,
+    },
+  });
+
+  return user;
+};
+
+// Delete all unverified accounts whose verification token has expired (48h cleanup)
+export const deleteExpiredUnverifiedUsers = async () => {
+  const result = await db.user.deleteMany({
+    where: {
+      isVerified: false,
+      verificationTokenExpiry: { lt: new Date() },
+    },
+  });
+
+  if (result.count > 0) {
+    console.log(`Cleanup: deleted ${result.count} expired unverified account(s).`);
+  }
+
+  return result.count;
 };

--- a/mvvm/src/app/(auth)/actions.ts
+++ b/mvvm/src/app/(auth)/actions.ts
@@ -15,21 +15,13 @@ const authLogInFormSchema = z.object({
 
 const authRegisterFormSchema = z.object({
   email: z.string().email({ message: "Please enter a valid email address" }),
-  username: z
-    .string()
-    .min(6, { message: "Username must be at least 6 characters long" }),
+  username: z.string().min(6, { message: "Username must be at least 6 characters long" }),
   password: z
     .string()
     .min(10, { message: "Password must be at least 10 characters long" })
-    .regex(/[A-Z]/, {
-      message: "Password must contain at least one uppercase letter",
-    })
-    .regex(/[a-z]/, {
-      message: "Password must contain at least one lowercase letter",
-    })
-    .regex(/[!@#$%^&*(),.?":{}|<>]/, {
-      message: "Password must contain at least one special character",
-    }),
+    .regex(/[A-Z]/, { message: "Password must contain at least one uppercase letter" })
+    .regex(/[a-z]/, { message: "Password must contain at least one lowercase letter" })
+    .regex(/[!@#$%^&*(),.?":{}|<>]/, { message: "Password must contain at least one special character" }),
   first_name: z.string().optional(),
   last_name: z.string().optional(),
   role: z.string(),
@@ -45,15 +37,9 @@ const resetPasswordSchema = z
     password: z
       .string()
       .min(10, { message: "Password must be at least 10 characters long" })
-      .regex(/[A-Z]/, {
-        message: "Password must contain at least one uppercase letter",
-      })
-      .regex(/[a-z]/, {
-        message: "Password must contain at least one lowercase letter",
-      })
-      .regex(/[!@#$%^&*(),.?":{}|<>]/, {
-        message: "Password must contain at least one special character",
-      }),
+      .regex(/[A-Z]/, { message: "Password must contain at least one uppercase letter" })
+      .regex(/[a-z]/, { message: "Password must contain at least one lowercase letter" })
+      .regex(/[!@#$%^&*(),.?":{}|<>]/, { message: "Password must contain at least one special character" }),
     confirmPassword: z.string(),
   })
   .refine((data) => data.password === data.confirmPassword, {
@@ -218,6 +204,36 @@ export const resetPassword = async (
       return { status: "invalid_data", error: errs };
     }
     console.error("Reset password action error:", error);
+    return { status: "failed" };
+  }
+};
+
+export interface VerifyEmailActionState {
+  status: "idle" | "success" | "failed" | "invalid_token";
+}
+
+export const verifyEmail = async (
+  _: VerifyEmailActionState,
+  formData: FormData,
+): Promise<VerifyEmailActionState> => {
+  try {
+    const token = formData.get("token") as string;
+    if (!token) return { status: "invalid_token" };
+
+    const res = await fetch(
+      `${process.env.NEXT_PUBLIC_BASE_URL}/users/verify-email`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token }),
+      },
+    );
+
+    if (res.status === 400) return { status: "invalid_token" };
+    if (!res.ok) return { status: "failed" };
+    return { status: "success" };
+  } catch (error) {
+    console.error("Verify email action error:", error);
     return { status: "failed" };
   }
 };

--- a/mvvm/src/app/(auth)/verify-email/page.tsx
+++ b/mvvm/src/app/(auth)/verify-email/page.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useVerifyEmailViewModel } from "@/view-models/auth/useVerifyEmailViewModel";
+import Form from "next/form";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { useFormStatus } from "react-dom";
+import { Suspense, useEffect } from "react";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="w-full rounded-lg bg-amber-800 px-4 py-2.5 text-sm font-semibold text-white shadow-md transition-all hover:bg-amber-700 disabled:opacity-60 dark:bg-amber-700 dark:hover:bg-amber-600"
+    >
+      {pending ? "Verifying..." : "Verify My Email"}
+    </button>
+  );
+}
+
+function VerifyEmailForm() {
+  const { state, formAction } = useVerifyEmailViewModel();
+  const searchParams = useSearchParams();
+  const token = searchParams.get("token");
+
+  useEffect(() => {
+    if (token) {
+      const formData = new FormData();
+      formData.append("token", token);
+      formAction(formData);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  if (!token) {
+    return (
+      <div className="rounded-lg border border-red-300 bg-red-50 px-6 py-5 text-center dark:border-red-700 dark:bg-red-950">
+        <p className="text-sm font-medium text-red-800 dark:text-red-300">
+          This verification link is missing a token. Please check your email for the correct link.
+        </p>
+        <Link href="/login" className="mt-3 inline-block text-sm font-semibold text-amber-800 hover:underline dark:text-amber-300">
+          Back to sign in
+        </Link>
+      </div>
+    );
+  }
+
+  if (state.status === "invalid_token") {
+    return (
+      <div className="rounded-lg border border-red-300 bg-red-50 px-6 py-5 text-center dark:border-red-700 dark:bg-red-950">
+        <p className="text-sm font-medium text-red-800 dark:text-red-300">
+          This verification link is invalid or has expired.
+        </p>
+        <p className="mt-2 text-xs text-red-600 dark:text-red-400">
+          Unverified accounts are removed after 48 hours. Please sign up again.
+        </p>
+        <Link href="/register" className="mt-3 inline-block text-sm font-semibold text-amber-800 hover:underline dark:text-amber-300">
+          Create a new account
+        </Link>
+      </div>
+    );
+  }
+
+  if (state.status === "success") {
+    return (
+      <div className="rounded-lg border border-green-300 bg-green-50 px-6 py-5 text-center dark:border-green-700 dark:bg-green-950">
+        <p className="text-sm font-medium text-green-800 dark:text-green-300">
+          🎉 Your email has been verified! Redirecting you to sign in...
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <Form action={formAction} className="flex flex-col gap-4">
+      <input type="hidden" name="token" value={token} />
+      <p className="text-center text-sm text-amber-700 dark:text-amber-300">
+        Click the button below to confirm your email address.
+      </p>
+      <SubmitButton />
+    </Form>
+  );
+}
+
+export default function VerifyEmailPage() {
+  return (
+    <div className="bg-login-bg flex h-dvh w-full items-start justify-center pt-12 md:items-center md:pt-0">
+      <div className="flex w-full max-w-md flex-col gap-8 overflow-hidden rounded-2xl px-4 sm:px-8">
+        <div className="flex flex-col items-center gap-2 text-center">
+          <h3 className="text-xl font-semibold text-amber-900 dark:text-amber-200">
+            Verifying your email...
+          </h3>
+          <p className="text-sm text-amber-700 dark:text-amber-300">
+            Hang tight, this only takes a moment.
+          </p>
+        </div>
+        <Suspense fallback={<div className="text-center text-sm text-amber-200 animate-pulse">Loading...</div>}>
+          <VerifyEmailForm />
+        </Suspense>
+        <p className="text-center text-sm text-white dark:text-amber-200">
+          Need help?{" "}
+          <Link href="/contact" className="font-semibold text-gray-800 hover:underline dark:text-white">
+            Contact us
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/mvvm/src/view-models/auth/useRegisterViewModel.tsx
+++ b/mvvm/src/view-models/auth/useRegisterViewModel.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { register, RegisterActionState } from "@/app/(auth)/actions";
-import { welcomeNewUser } from "@/lib/services/contact-service";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
 import { useActionState, useEffect, useState } from "react";
@@ -42,9 +41,8 @@ export const useRegisterViewModel = () => {
         description: toastee,
       });
     } else if (state.status === "success") {
-      toast.success("Account created successfully");
+      toast.success("Account created! Please check your email to verify your account.");
       setIsSuccessful(true);
-      welcomeNewUser({ email, username });
       update();
       router.push("/");
     }

--- a/mvvm/src/view-models/auth/useVerifyEmailViewModel.ts
+++ b/mvvm/src/view-models/auth/useVerifyEmailViewModel.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useActionState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { verifyEmail, VerifyEmailActionState } from "@/app/(auth)/actions";
+
+export const useVerifyEmailViewModel = () => {
+  const router = useRouter();
+
+  const [state, formAction] = useActionState<VerifyEmailActionState, FormData>(
+    verifyEmail,
+    { status: "idle" },
+  );
+
+  useEffect(() => {
+    if (state.status === "success") {
+      toast.success("Email verified! Welcome aboard.");
+      router.push("/login");
+    } else if (state.status === "invalid_token") {
+      toast.error("This verification link is invalid or has expired.");
+    } else if (state.status === "failed") {
+      toast.error("Something went wrong. Please try again.");
+    }
+  }, [state, router]);
+
+  return { state, formAction };
+};


### PR DESCRIPTION


Backend:
- Add verificationToken and verificationTokenExpiry to User model in Prisma schema
- Add createVerificationToken, verifyAccountToken, findUserByVerificationToken, and deleteExpiredUnverifiedUsers to usersService
- Add verificationEmail to contactService with warm, informative tone; clearly informs user of 48h expiry and account deletion policy
- Update createNewUserController to generate token and fire verification + welcome emails concurrently on registration
- Add verifyEmailController and POST /users/verify-email route
- Add hourly cleanup job via setInterval that deletes expired unverified accounts; also runs once immediately on server start

Frontend:
- Add verifyEmail server action and VerifyEmailActionState to actions.ts
- Add useVerifyEmailViewModel with toast handling and redirect to /login on success
- Add /verify-email page that auto-submits on load, with fallback manual button, error states for missing/expired tokens, and success confirmation
- Remove welcomeNewUser call from useRegisterViewModel (backend now handles it)
- Update register success toast to inform user to check email for verification