### PR TITLE
feat: Full-viewport image viewer with zoom, pan, and precise cursor

### DIFF
--- a/mvvm/src/components/containers/image-container.tsx
+++ b/mvvm/src/components/containers/image-container.tsx
@@ -16,17 +16,43 @@ const ZOOM_STEP = 0.5;
 const DOUBLE_TAP_DELAY = 300;
 const CLICK_MOVE_THRESHOLD = 5;
 
+function getContainRect(
+  containerW: number,
+  containerH: number,
+  imgW: number,
+  imgH: number,
+) {
+  const containerRatio = containerW / containerH;
+  const imgRatio = imgW / imgH;
+  let width: number, height: number;
+  if (imgRatio > containerRatio) {
+    width = containerW;
+    height = containerW / imgRatio;
+  } else {
+    height = containerH;
+    width = containerH * imgRatio;
+  }
+  return {
+    left: (containerW - width) / 2,
+    top: (containerH - height) / 2,
+    width,
+    height,
+  };
+}
+
 export default function ImageGallery({ images }: ImageGalleryProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [open, setOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
+  const [naturalSize, setNaturalSize] = useState<{ w: number; h: number } | null>(null);
+  const [containerSize, setContainerSize] = useState<{ w: number; h: number } | null>(null);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const imageWrapRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const hasDragged = useRef(false);
+  const mouseDownPos = useRef({ x: 0, y: 0 });
   const dragStart = useRef({ x: 0, y: 0 });
   const panAtDragStart = useRef({ x: 0, y: 0 });
   const lastTap = useRef(0);
@@ -44,8 +70,20 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
   }, []);
 
   useEffect(() => {
+    if (!open) return;
+    const measure = () => {
+      const el = containerRef.current;
+      if (el) setContainerSize({ w: el.clientWidth, h: el.clientHeight });
+    };
+    measure();
+    window.addEventListener("resize", measure);
+    return () => window.removeEventListener("resize", measure);
+  }, [open]);
+
+  useEffect(() => {
     if (selectedIndex !== null && selectedIndex !== prevIndexRef.current) {
       setIsLoading(true);
+      setNaturalSize(null);
       prevIndexRef.current = selectedIndex;
     }
   }, [selectedIndex]);
@@ -105,6 +143,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
   useEffect(() => {
     const el = containerRef.current;
     if (!el || !open) return;
+
     const onWheel = (e: WheelEvent) => {
       e.preventDefault();
       setZoom((prev) => {
@@ -113,33 +152,53 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
         return next;
       });
     };
-    el.addEventListener("wheel", onWheel, { passive: false });
-    return () => el.removeEventListener("wheel", onWheel);
-  }, [open]);
 
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (zoomRef.current <= 1) return;
+      hasDragged.current = false;
+      isDragging.current = true;
+      mouseDownPos.current = { x: e.clientX, y: e.clientY };
+      dragStart.current = { x: e.clientX, y: e.clientY };
+      panAtDragStart.current = panRef.current;
+      e.preventDefault();
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      const dx = e.clientX - dragStart.current.x;
+      const dy = e.clientY - dragStart.current.y;
+      if (Math.hypot(e.clientX - mouseDownPos.current.x, e.clientY - mouseDownPos.current.y) > CLICK_MOVE_THRESHOLD) {
+        hasDragged.current = true;
+      }
+      setPan(clampPan(panAtDragStart.current.x + dx, panAtDragStart.current.y + dy, zoomRef.current));
+    };
+
+    const onMouseUp = () => { isDragging.current = false; };
 
     const onTouchStart = (e: TouchEvent) => {
       if (e.touches.length === 2) {
         const dx = e.touches[0].clientX - e.touches[1].clientX;
         const dy = e.touches[0].clientY - e.touches[1].clientY;
         lastPinchDist.current = Math.hypot(dx, dy);
-        const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
-        const midY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
-        dragStart.current = { x: midX, y: midY };
         panAtDragStart.current = panRef.current;
+        dragStart.current = {
+          x: (e.touches[0].clientX + e.touches[1].clientX) / 2,
+          y: (e.touches[0].clientY + e.touches[1].clientY) / 2,
+        };
       } else if (e.touches.length === 1) {
         const now = Date.now();
-        if (now - lastTap.current < DOUBLE_TAP_DELAY) {
+        const isDoubleTap = now - lastTap.current < DOUBLE_TAP_DELAY && lastTap.current !== 0;
+        if (isDoubleTap) {
+          e.preventDefault();
           if (zoomRef.current > 1) { setZoom(1); setPan({ x: 0, y: 0 }); }
-          else { setZoom(2.5); }
+          else setZoom(2.5);
           lastTap.current = 0;
+          isDragging.current = false;
           return;
         }
         lastTap.current = now;
         isDragging.current = true;
+        hasDragged.current = false;
         dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
         panAtDragStart.current = panRef.current;
       }
@@ -161,6 +220,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
       } else if (e.touches.length === 1 && isDragging.current && zoomRef.current > 1) {
         const dx = e.touches[0].clientX - dragStart.current.x;
         const dy = e.touches[0].clientY - dragStart.current.y;
+        if (Math.hypot(dx, dy) > CLICK_MOVE_THRESHOLD) hasDragged.current = true;
         setPan(clampPan(
           panAtDragStart.current.x + dx,
           panAtDragStart.current.y + dy,
@@ -176,51 +236,42 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
         dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
         panAtDragStart.current = panRef.current;
         isDragging.current = true;
+        hasDragged.current = false;
       }
     };
 
+    el.addEventListener("wheel", onWheel, { passive: false });
+    el.addEventListener("mousedown", onMouseDown);
+    el.addEventListener("mousemove", onMouseMove);
+    el.addEventListener("mouseup", onMouseUp);
     el.addEventListener("touchstart", onTouchStart, { passive: false });
     el.addEventListener("touchmove", onTouchMove, { passive: false });
     el.addEventListener("touchend", onTouchEnd);
+
     return () => {
+      el.removeEventListener("wheel", onWheel);
+      el.removeEventListener("mousedown", onMouseDown);
+      el.removeEventListener("mousemove", onMouseMove);
+      el.removeEventListener("mouseup", onMouseUp);
       el.removeEventListener("touchstart", onTouchStart);
       el.removeEventListener("touchmove", onTouchMove);
       el.removeEventListener("touchend", onTouchEnd);
     };
   }, [open, clampPan]);
 
-  const onPointerDown = (e: React.PointerEvent) => {
-    if (e.pointerType === "touch") return;
-    if (zoomRef.current <= 1) return;
-    hasDragged.current = false;
-    isDragging.current = true;
-    dragStart.current = { x: e.clientX, y: e.clientY };
-    panAtDragStart.current = pan;
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
-  };
-
-  const onPointerMove = (e: React.PointerEvent) => {
-    if (!isDragging.current) return;
-    const dx = e.clientX - dragStart.current.x;
-    const dy = e.clientY - dragStart.current.y;
-    if (Math.hypot(dx, dy) > CLICK_MOVE_THRESHOLD) hasDragged.current = true;
-    setPan(clampPan(panAtDragStart.current.x + dx, panAtDragStart.current.y + dy, zoom));
-  };
-
-  const onPointerUp = () => { isDragging.current = false; };
-
-  const onImageClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
+  const onImageOverlayClick = useCallback(() => {
     if (hasDragged.current) return;
-    if (zoomRef.current > 1) resetZoomPan();
+    if (zoomRef.current > 1) { setZoom(1); setPan({ x: 0, y: 0 }); }
     else setZoom(2.5);
-  };
+  }, []);
 
-  const imageCursor = zoom > 1
-    ? isDragging.current ? "grabbing" : "grab"
-    : "zoom-in";
-
+  const imageCursor = zoom > 1 ? "grab" : "zoom-in";
   const imageTransform = `scale(${zoom}) translate(${pan.x / zoom}px, ${pan.y / zoom}px)`;
+
+  const containRect =
+    containerSize && naturalSize
+      ? getContainRect(containerSize.w, containerSize.h, naturalSize.w, naturalSize.h)
+      : null;
 
   return (
     <>
@@ -265,13 +316,13 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
               <VisuallyHidden>Image viewer</VisuallyHidden>
             </Dialog.Title>
 
-            <div className="absolute top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3">
+            <div className="absolute top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3 pointer-events-none">
               <p className="text-sm font-semibold text-white drop-shadow">
                 {selectedIndex !== null ? `${selectedIndex + 1} / ${images.length}` : ""}
               </p>
               <Dialog.Close
                 onClick={closeModal}
-                className="rounded-full bg-black/60 p-2 text-white cursor-pointer hover:bg-black/80"
+                className="rounded-full bg-black/60 p-2 text-white cursor-pointer hover:bg-black/80 pointer-events-auto"
               >
                 <X className="h-6 w-6" />
               </Dialog.Close>
@@ -280,39 +331,51 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
             <div
               ref={containerRef}
               className="relative flex h-full w-full items-center justify-center overflow-hidden"
-              onPointerDown={onPointerDown}
-              onPointerMove={onPointerMove}
-              onPointerUp={onPointerUp}
             >
               {isLoading && (
                 <div className="h-[70vh] w-[85vw] max-w-5xl animate-pulse rounded-lg bg-gray-700" />
               )}
 
               {selectedIndex !== null && images[selectedIndex] && (
+                <Image
+                  src={images[selectedIndex]!.original}
+                  alt={`Full image ${selectedIndex + 1}`}
+                  fill
+                  loading="eager"
+                  sizes="100vw"
+                  className="rounded-lg object-contain select-none"
+                  style={{
+                    opacity: isLoading ? 0 : 1,
+                    transform: imageTransform,
+                    cursor: "default",
+                    transition: isDragging.current
+                      ? "none"
+                      : "transform 0.15s ease, opacity 0.3s",
+                    pointerEvents: "none",
+                  }}
+                  onLoad={(e) => {
+                    setIsLoading(false);
+                    const img = e.currentTarget as HTMLImageElement;
+                    setNaturalSize({ w: img.naturalWidth, h: img.naturalHeight });
+                    const el = containerRef.current;
+                    if (el) setContainerSize({ w: el.clientWidth, h: el.clientHeight });
+                  }}
+                  draggable={false}
+                />
+              )}
+
+              {containRect && !isLoading && (
                 <div
-                  ref={imageWrapRef}
-                  className="absolute inset-0"
-                  style={{ cursor: imageCursor }}
-                  onClick={onImageClick}
-                >
-                  <Image
-                    src={images[selectedIndex]!.original}
-                    alt={`Full image ${selectedIndex + 1}`}
-                    fill
-                    loading="eager"
-                    sizes="100vw"
-                    className="rounded-lg object-contain select-none pointer-events-none"
-                    style={{
-                      opacity: isLoading ? 0 : 1,
-                      transform: imageTransform,
-                      transition: isDragging.current
-                        ? "none"
-                        : "transform 0.15s ease, opacity 0.3s",
-                    }}
-                    onLoad={() => setIsLoading(false)}
-                    draggable={false}
-                  />
-                </div>
+                  className="absolute z-10"
+                  style={{
+                    left: containRect.left,
+                    top: containRect.top,
+                    width: containRect.width,
+                    height: containRect.height,
+                    cursor: imageCursor,
+                  }}
+                  onClick={onImageOverlayClick}
+                />
               )}
             </div>
 

--- a/mvvm/src/components/containers/image-container.tsx
+++ b/mvvm/src/components/containers/image-container.tsx
@@ -14,8 +14,34 @@ const MIN_ZOOM = 1;
 const MAX_ZOOM = 5;
 const ZOOM_STEP = 0.5;
 const DOUBLE_TAP_DELAY = 300;
-// If mouse moves more than this during a click, treat it as a drag not a click
 const CLICK_MOVE_THRESHOLD = 5;
+
+function getContainRect(
+  containerW: number,
+  containerH: number,
+  imgW: number,
+  imgH: number,
+  zoom: number,
+) {
+  const containerRatio = containerW / containerH;
+  const imgRatio = imgW / imgH;
+  let baseWidth: number, baseHeight: number;
+  if (imgRatio > containerRatio) {
+    baseWidth = containerW;
+    baseHeight = containerW / imgRatio;
+  } else {
+    baseHeight = containerH;
+    baseWidth = containerH * imgRatio;
+  }
+  const width = Math.min(containerW, baseWidth * zoom);
+  const height = Math.min(containerH, baseHeight * zoom);
+  return {
+    left: (containerW - width) / 2,
+    top: (containerH - height) / 2,
+    width,
+    height,
+  };
+}
 
 export default function ImageGallery({ images }: ImageGalleryProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
@@ -27,9 +53,9 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
   const [containerSize, setContainerSize] = useState<{ w: number; h: number } | null>(null);
 
   const containerRef = useRef<HTMLDivElement>(null);
-  const imageWrapRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
   const hasDragged = useRef(false);
+  const mouseDownPos = useRef({ x: 0, y: 0 });
   const dragStart = useRef({ x: 0, y: 0 });
   const panAtDragStart = useRef({ x: 0, y: 0 });
   const lastTap = useRef(0);
@@ -38,8 +64,10 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
 
   const zoomRef = useRef(zoom);
   const panRef = useRef(pan);
+  const openRef = useRef(open);
   useEffect(() => { zoomRef.current = zoom; }, [zoom]);
   useEffect(() => { panRef.current = pan; }, [pan]);
+  useEffect(() => { openRef.current = open; }, [open]);
 
   const resetZoomPan = useCallback(() => {
     setZoom(1);
@@ -47,14 +75,30 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
   }, []);
 
   useEffect(() => {
+    if (!open) return;
+    const measure = () => {
+      const el = containerRef.current;
+      if (el) setContainerSize({ w: el.clientWidth, h: el.clientHeight });
+    };
+    const t = setTimeout(measure, 50);
+    window.addEventListener("resize", measure);
+    return () => {
+      clearTimeout(t);
+      window.removeEventListener("resize", measure);
+    };
+  }, [open]);
+
+  useEffect(() => {
     if (selectedIndex !== null && selectedIndex !== prevIndexRef.current) {
       setIsLoading(true);
+      setNaturalSize(null);
       prevIndexRef.current = selectedIndex;
     }
   }, [selectedIndex]);
 
   const showPrev = useCallback(() => {
     setSelectedIndex((prev) => (prev !== null && prev > 0 ? prev - 1 : prev));
+    hasDragged.current = false;
     resetZoomPan();
   }, [resetZoomPan]);
 
@@ -62,25 +106,16 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
     setSelectedIndex((prev) =>
       prev !== null && prev < images.length - 1 ? prev + 1 : prev,
     );
+    hasDragged.current = false;
     resetZoomPan();
   }, [images.length, resetZoomPan]);
 
   const closeModal = useCallback(() => {
     setOpen(false);
     setSelectedIndex(null);
+    hasDragged.current = false;
     resetZoomPan();
   }, [resetZoomPan]);
-
-  const clampPan = useCallback((x: number, y: number, currentZoom: number) => {
-    const el = containerRef.current;
-    if (!el) return { x, y };
-    const maxPanX = (el.clientWidth * (currentZoom - 1)) / 2;
-    const maxPanY = (el.clientHeight * (currentZoom - 1)) / 2;
-    return {
-      x: Math.min(maxPanX, Math.max(-maxPanX, x)),
-      y: Math.min(maxPanY, Math.max(-maxPanY, y)),
-    };
-  }, []);
 
   const zoomIn = useCallback(() => {
     setZoom((prev) => Math.min(MAX_ZOOM, parseFloat((prev + ZOOM_STEP).toFixed(1))));
@@ -94,24 +129,22 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
     });
   }, []);
 
-  // Keyboard support
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
-      if (!open || selectedIndex === null) return;
+      if (!openRef.current || selectedIndex === null) return;
       if (e.key === "ArrowLeft") showPrev();
       if (e.key === "ArrowRight") showNext();
       if (e.key === "Escape") closeModal();
     };
     window.addEventListener("keydown", handleKey);
     return () => window.removeEventListener("keydown", handleKey);
-  }, [selectedIndex, open, showPrev, showNext, closeModal]);
+  }, [selectedIndex, showPrev, showNext, closeModal]);
 
-  // Mouse wheel zoom
   useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !open) return;
-
     const onWheel = (e: WheelEvent) => {
+      if (!openRef.current) return;
+      const el = containerRef.current;
+      if (!el || !el.contains(e.target as Node)) return;
       e.preventDefault();
       setZoom((prev) => {
         const next = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, prev - e.deltaY * 0.005));
@@ -120,20 +153,51 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
       });
     };
 
-  // Touch events
-  useEffect(() => {
-    const el = containerRef.current;
-    if (!el || !open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (!openRef.current) return;
+      const el = containerRef.current;
+      if (!el || !el.contains(e.target as Node)) return;
+      if (zoomRef.current <= 1) return;
+      hasDragged.current = false;
+      isDragging.current = true;
+      mouseDownPos.current = { x: e.clientX, y: e.clientY };
+      dragStart.current = { x: e.clientX, y: e.clientY };
+      panAtDragStart.current = panRef.current;
+      e.preventDefault();
+    };
+
+    const onMouseMove = (e: MouseEvent) => {
+      if (!isDragging.current) return;
+      const dx = e.clientX - dragStart.current.x;
+      const dy = e.clientY - dragStart.current.y;
+      if (Math.hypot(e.clientX - mouseDownPos.current.x, e.clientY - mouseDownPos.current.y) > CLICK_MOVE_THRESHOLD) {
+        hasDragged.current = true;
+      }
+      const el = containerRef.current;
+      if (!el) return;
+      const maxPanX = (el.clientWidth * (zoomRef.current - 1)) / 2;
+      const maxPanY = (el.clientHeight * (zoomRef.current - 1)) / 2;
+      setPan({
+        x: Math.min(maxPanX, Math.max(-maxPanX, panAtDragStart.current.x + dx)),
+        y: Math.min(maxPanY, Math.max(-maxPanY, panAtDragStart.current.y + dy)),
+      });
+    };
+
+    const onMouseUp = () => { isDragging.current = false; };
 
     const onTouchStart = (e: TouchEvent) => {
+      if (!openRef.current) return;
+      const el = containerRef.current;
+      if (!el) return;
       if (e.touches.length === 2) {
         const dx = e.touches[0].clientX - e.touches[1].clientX;
         const dy = e.touches[0].clientY - e.touches[1].clientY;
         lastPinchDist.current = Math.hypot(dx, dy);
-        const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
-        const midY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
-        dragStart.current = { x: midX, y: midY };
         panAtDragStart.current = panRef.current;
+        dragStart.current = {
+          x: (e.touches[0].clientX + e.touches[1].clientX) / 2,
+          y: (e.touches[0].clientY + e.touches[1].clientY) / 2,
+        };
       } else if (e.touches.length === 1) {
         const now = Date.now();
         const isDoubleTap = now - lastTap.current < DOUBLE_TAP_DELAY && lastTap.current !== 0;
@@ -147,13 +211,17 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
         }
         lastTap.current = now;
         isDragging.current = true;
+        hasDragged.current = false;
         dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
         panAtDragStart.current = panRef.current;
       }
     };
 
     const onTouchMove = (e: TouchEvent) => {
+      if (!openRef.current) return;
       e.preventDefault();
+      const el = containerRef.current;
+      if (!el) return;
       if (e.touches.length === 2 && lastPinchDist.current !== null) {
         const dx = e.touches[0].clientX - e.touches[1].clientX;
         const dy = e.touches[0].clientY - e.touches[1].clientY;
@@ -168,11 +236,13 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
       } else if (e.touches.length === 1 && isDragging.current && zoomRef.current > 1) {
         const dx = e.touches[0].clientX - dragStart.current.x;
         const dy = e.touches[0].clientY - dragStart.current.y;
-        setPan(clampPan(
-          panAtDragStart.current.x + dx,
-          panAtDragStart.current.y + dy,
-          zoomRef.current,
-        ));
+        if (Math.hypot(dx, dy) > CLICK_MOVE_THRESHOLD) hasDragged.current = true;
+        const maxPanX = (el.clientWidth * (zoomRef.current - 1)) / 2;
+        const maxPanY = (el.clientHeight * (zoomRef.current - 1)) / 2;
+        setPan({
+          x: Math.min(maxPanX, Math.max(-maxPanX, panAtDragStart.current.x + dx)),
+          y: Math.min(maxPanY, Math.max(-maxPanY, panAtDragStart.current.y + dy)),
+        });
       }
     };
 
@@ -183,62 +253,44 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
         dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
         panAtDragStart.current = panRef.current;
         isDragging.current = true;
+        hasDragged.current = false;
       }
     };
 
-    el.addEventListener("wheel", onWheel, { passive: false });
-    el.addEventListener("mousedown", onMouseDown);
-    el.addEventListener("mousemove", onMouseMove);
-    el.addEventListener("mouseup", onMouseUp);
-    el.addEventListener("touchstart", onTouchStart, { passive: false });
-    el.addEventListener("touchmove", onTouchMove, { passive: false });
-    el.addEventListener("touchend", onTouchEnd);
+    window.addEventListener("wheel", onWheel, { passive: false });
+    window.addEventListener("mousedown", onMouseDown);
+    window.addEventListener("mousemove", onMouseMove);
+    window.addEventListener("mouseup", onMouseUp);
+    window.addEventListener("touchstart", onTouchStart, { passive: false });
+    window.addEventListener("touchmove", onTouchMove, { passive: false });
+    window.addEventListener("touchend", onTouchEnd);
 
     return () => {
-      el.removeEventListener("wheel", onWheel);
-      el.removeEventListener("mousedown", onMouseDown);
-      el.removeEventListener("mousemove", onMouseMove);
-      el.removeEventListener("mouseup", onMouseUp);
-      el.removeEventListener("touchstart", onTouchStart);
-      el.removeEventListener("touchmove", onTouchMove);
-      el.removeEventListener("touchend", onTouchEnd);
+      window.removeEventListener("wheel", onWheel);
+      window.removeEventListener("mousedown", onMouseDown);
+      window.removeEventListener("mousemove", onMouseMove);
+      window.removeEventListener("mouseup", onMouseUp);
+      window.removeEventListener("touchstart", onTouchStart);
+      window.removeEventListener("touchmove", onTouchMove);
+      window.removeEventListener("touchend", onTouchEnd);
     };
-  }, [open, clampPan]);
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-  // ── Mouse drag-to-pan on the container (captures pointer even off-image) ──
-  const onPointerDown = (e: React.PointerEvent) => {
-    if (e.pointerType === "touch") return;
-    if (zoomRef.current <= 1) return;
-    hasDragged.current = false;
-    isDragging.current = true;
-    dragStart.current = { x: e.clientX, y: e.clientY };
-    panAtDragStart.current = pan;
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
-  };
-
-  const onPointerMove = (e: React.PointerEvent) => {
-    if (!isDragging.current) return;
-    const dx = e.clientX - dragStart.current.x;
-    const dy = e.clientY - dragStart.current.y;
-    if (Math.hypot(dx, dy) > CLICK_MOVE_THRESHOLD) hasDragged.current = true;
-    setPan(clampPan(panAtDragStart.current.x + dx, panAtDragStart.current.y + dy, zoom));
-  };
-
-  const onPointerUp = () => { isDragging.current = false; };
-
-  // ── Single click on the IMAGE WRAPPER toggles zoom ────────────────────────
-  const onImageClick = (e: React.MouseEvent) => {
-    e.stopPropagation();
-    if (hasDragged.current) return; // was a drag, not a click
-    if (zoomRef.current > 1) resetZoomPan();
+  const onImageOverlayClick = useCallback((e: React.MouseEvent) => {
+    if (e.nativeEvent.pointerType === "touch") return;
+    if (hasDragged.current) return;
+    if (zoomRef.current > 1) { setZoom(1); setPan({ x: 0, y: 0 }); }
     else setZoom(2.5);
   }, []);
 
-  const imageCursor = zoom > 1
-    ? isDragging.current ? "grabbing" : "grab"
-    : "zoom-in";
-
+  const imageCursor = zoom > 1 ? "grab" : "zoom-in";
   const imageTransform = `scale(${zoom}) translate(${pan.x / zoom}px, ${pan.y / zoom}px)`;
+
+  const containRect =
+    containerSize && naturalSize
+      ? getContainRect(containerSize.w, containerSize.h, naturalSize.w, naturalSize.h, zoom)
+      : null;
 
   return (
     <>
@@ -270,7 +322,11 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
         open={open}
         onOpenChange={(isOpen: boolean) => {
           setOpen(isOpen);
-          if (!isOpen) { setSelectedIndex(null); resetZoomPan(); }
+          if (!isOpen) {
+            setSelectedIndex(null);
+            hasDragged.current = false;
+            resetZoomPan();
+          }
         }}
       >
         <Dialog.Portal>
@@ -283,57 +339,51 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
               <VisuallyHidden>Image viewer</VisuallyHidden>
             </Dialog.Title>
 
-            {/* ── Top bar ── */}
-            <div className="absolute top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3">
+            <div className="absolute top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3 pointer-events-none">
               <p className="text-sm font-semibold text-white drop-shadow">
                 {selectedIndex !== null ? `${selectedIndex + 1} / ${images.length}` : ""}
               </p>
               <Dialog.Close
                 onClick={closeModal}
-                className="rounded-full bg-black/60 p-2 text-white cursor-pointer hover:bg-black/80"
+                className="rounded-full bg-black/60 p-2 text-white cursor-pointer hover:bg-black/80 pointer-events-auto"
               >
                 <X className="h-6 w-6" />
               </Dialog.Close>
             </div>
 
-            {/* ── Image area — default cursor, drag captured here ── */}
             <div
               ref={containerRef}
               className="relative flex h-full w-full items-center justify-center overflow-hidden"
-              onPointerDown={onPointerDown}
-              onPointerMove={onPointerMove}
-              onPointerUp={onPointerUp}
             >
               {isLoading && (
                 <div className="h-[70vh] w-[85vw] max-w-5xl animate-pulse rounded-lg bg-gray-700" />
               )}
 
-              {/* Image wrapper — zoom cursor + single-click zoom only on the actual photo */}
               {selectedIndex !== null && images[selectedIndex] && (
-                <div
-                  ref={imageWrapRef}
-                  className="absolute inset-0"
-                  style={{ cursor: imageCursor }}
-                  onClick={onImageClick}
-                >
-                  <Image
-                    src={images[selectedIndex]!.original}
-                    alt={`Full image ${selectedIndex + 1}`}
-                    fill
-                    loading="eager"
-                    sizes="100vw"
-                    className="rounded-lg object-contain select-none pointer-events-none"
-                    style={{
-                      opacity: isLoading ? 0 : 1,
-                      transform: imageTransform,
-                      transition: isDragging.current
-                        ? "none"
-                        : "transform 0.15s ease, opacity 0.3s",
-                    }}
-                    onLoad={() => setIsLoading(false)}
-                    draggable={false}
-                  />
-                </div>
+                <Image
+                  src={images[selectedIndex]!.original}
+                  alt={`Full image ${selectedIndex + 1}`}
+                  fill
+                  loading="eager"
+                  sizes="100vw"
+                  className="rounded-lg object-contain select-none"
+                  style={{
+                    opacity: isLoading ? 0 : 1,
+                    transform: imageTransform,
+                    transition: isDragging.current
+                      ? "none"
+                      : "transform 0.15s ease, opacity 0.3s",
+                    pointerEvents: "none",
+                  }}
+                  onLoad={(e) => {
+                    setIsLoading(false);
+                    const img = e.currentTarget as HTMLImageElement;
+                    setNaturalSize({ w: img.naturalWidth, h: img.naturalHeight });
+                    const el = containerRef.current;
+                    if (el) setContainerSize({ w: el.clientWidth, h: el.clientHeight });
+                  }}
+                  draggable={false}
+                />
               )}
 
               {containRect && !isLoading && (
@@ -351,7 +401,6 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
               )}
             </div>
 
-            {/* ── Prev arrow ── */}
             {selectedIndex !== null && selectedIndex > 0 && (
               <button
                 onClick={showPrev}
@@ -361,7 +410,6 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
               </button>
             )}
 
-            {/* ── Next arrow ── */}
             {selectedIndex !== null && selectedIndex < images.length - 1 && (
               <button
                 onClick={showNext}
@@ -371,7 +419,6 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
               </button>
             )}
 
-            {/* ── Zoom controls ── */}
             {!isLoading && (
               <div className="absolute bottom-10 right-4 z-50 flex flex-col overflow-hidden rounded-lg shadow-lg md:bottom-8 md:right-6">
                 <button

--- a/mvvm/src/components/containers/image-container.tsx
+++ b/mvvm/src/components/containers/image-container.tsx
@@ -14,6 +14,7 @@ const MIN_ZOOM = 1;
 const MAX_ZOOM = 5;
 const ZOOM_STEP = 0.5;
 const DOUBLE_TAP_DELAY = 300;
+const CLICK_MOVE_THRESHOLD = 5;
 
 export default function ImageGallery({ images }: ImageGalleryProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
@@ -23,7 +24,9 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
   const [pan, setPan] = useState({ x: 0, y: 0 });
 
   const containerRef = useRef<HTMLDivElement>(null);
+  const imageWrapRef = useRef<HTMLDivElement>(null);
   const isDragging = useRef(false);
+  const hasDragged = useRef(false);
   const dragStart = useRef({ x: 0, y: 0 });
   const panAtDragStart = useRef({ x: 0, y: 0 });
   const lastTap = useRef(0);
@@ -158,12 +161,11 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
       } else if (e.touches.length === 1 && isDragging.current && zoomRef.current > 1) {
         const dx = e.touches[0].clientX - dragStart.current.x;
         const dy = e.touches[0].clientY - dragStart.current.y;
-        const clamped = clampPan(
+        setPan(clampPan(
           panAtDragStart.current.x + dx,
           panAtDragStart.current.y + dy,
           zoomRef.current,
-        );
-        setPan(clamped);
+        ));
       }
     };
 
@@ -190,6 +192,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
   const onPointerDown = (e: React.PointerEvent) => {
     if (e.pointerType === "touch") return;
     if (zoomRef.current <= 1) return;
+    hasDragged.current = false;
     isDragging.current = true;
     dragStart.current = { x: e.clientX, y: e.clientY };
     panAtDragStart.current = pan;
@@ -200,22 +203,24 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
     if (!isDragging.current) return;
     const dx = e.clientX - dragStart.current.x;
     const dy = e.clientY - dragStart.current.y;
+    if (Math.hypot(dx, dy) > CLICK_MOVE_THRESHOLD) hasDragged.current = true;
     setPan(clampPan(panAtDragStart.current.x + dx, panAtDragStart.current.y + dy, zoom));
   };
 
   const onPointerUp = () => { isDragging.current = false; };
 
-  const onDoubleClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    if (zoom > 1) resetZoomPan();
+  const onImageClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (hasDragged.current) return;
+    if (zoomRef.current > 1) resetZoomPan();
     else setZoom(2.5);
   };
 
+  const imageCursor = zoom > 1
+    ? isDragging.current ? "grabbing" : "grab"
+    : "zoom-in";
+
   const imageTransform = `scale(${zoom}) translate(${pan.x / zoom}px, ${pan.y / zoom}px)`;
-  const imageCursor =
-    zoom > 1
-      ? isDragging.current ? "grabbing" : "grab"
-      : "zoom-in";
 
   return (
     <>
@@ -252,7 +257,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
       >
         <Dialog.Portal>
           <Dialog.Overlay className="fixed inset-0 z-50 bg-black/90" />
-          <Dialog.Content className="fixed inset-0 z-50 flex flex-col items-center justify-center">
+          <Dialog.Content className="fixed inset-0 z-50 flex flex-col items-center justify-center cursor-default">
             <VisuallyHidden>
               <Dialog.Description>Image viewer for blog photos.</Dialog.Description>
             </VisuallyHidden>
@@ -266,7 +271,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
               </p>
               <Dialog.Close
                 onClick={closeModal}
-                className="rounded-full bg-black/60 p-2 text-white hover:cursor-pointer hover:bg-black/80"
+                className="rounded-full bg-black/60 p-2 text-white cursor-pointer hover:bg-black/80"
               >
                 <X className="h-6 w-6" />
               </Dialog.Close>
@@ -278,38 +283,43 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
               onPointerDown={onPointerDown}
               onPointerMove={onPointerMove}
               onPointerUp={onPointerUp}
-              onDoubleClick={onDoubleClick}
             >
               {isLoading && (
                 <div className="h-[70vh] w-[85vw] max-w-5xl animate-pulse rounded-lg bg-gray-700" />
               )}
 
               {selectedIndex !== null && images[selectedIndex] && (
-                <Image
-                  src={images[selectedIndex]!.original}
-                  alt={`Full image ${selectedIndex + 1}`}
-                  fill
-                  loading="eager"
-                  sizes="100vw"
-                  className="rounded-lg object-contain select-none"
-                  style={{
-                    opacity: isLoading ? 0 : 1,
-                    transform: imageTransform,
-                    cursor: imageCursor,
-                    transition: isDragging.current
-                      ? "none"
-                      : "transform 0.15s ease, opacity 0.3s",
-                  }}
-                  onLoad={() => setIsLoading(false)}
-                  draggable={false}
-                />
+                <div
+                  ref={imageWrapRef}
+                  className="absolute inset-0"
+                  style={{ cursor: imageCursor }}
+                  onClick={onImageClick}
+                >
+                  <Image
+                    src={images[selectedIndex]!.original}
+                    alt={`Full image ${selectedIndex + 1}`}
+                    fill
+                    loading="eager"
+                    sizes="100vw"
+                    className="rounded-lg object-contain select-none pointer-events-none"
+                    style={{
+                      opacity: isLoading ? 0 : 1,
+                      transform: imageTransform,
+                      transition: isDragging.current
+                        ? "none"
+                        : "transform 0.15s ease, opacity 0.3s",
+                    }}
+                    onLoad={() => setIsLoading(false)}
+                    draggable={false}
+                  />
+                </div>
               )}
             </div>
 
             {selectedIndex !== null && selectedIndex > 0 && (
               <button
                 onClick={showPrev}
-                className="absolute left-3 top-1/2 z-50 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white hover:bg-black/80 md:left-6"
+                className="absolute left-3 top-1/2 z-50 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white cursor-pointer hover:bg-black/80 md:left-6"
               >
                 <ChevronLeft className="h-6 w-6" />
               </button>
@@ -318,7 +328,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
             {selectedIndex !== null && selectedIndex < images.length - 1 && (
               <button
                 onClick={showNext}
-                className="absolute right-3 top-1/2 z-50 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white hover:bg-black/80 md:right-6"
+                className="absolute right-3 top-1/2 z-50 -translate-y-1/2 rounded-full bg-black/60 p-2 text-white cursor-pointer hover:bg-black/80 md:right-6"
               >
                 <ChevronRight className="h-6 w-6" />
               </button>
@@ -329,7 +339,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
                 <button
                   onClick={zoomIn}
                   disabled={zoom >= MAX_ZOOM}
-                  className="flex items-center justify-center bg-black/60 px-3 py-2 text-white hover:bg-black/80 disabled:opacity-30 border-b border-white/20"
+                  className="flex items-center justify-center bg-black/60 px-3 py-2 text-white hover:bg-black/80 disabled:opacity-30 border-b border-white/20 cursor-pointer disabled:cursor-default"
                   aria-label="Zoom in"
                 >
                   <ZoomIn className="h-4 w-4" />
@@ -337,18 +347,12 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
                 <button
                   onClick={zoomOut}
                   disabled={zoom <= MIN_ZOOM}
-                  className="flex items-center justify-center bg-black/60 px-3 py-2 text-white hover:bg-black/80 disabled:opacity-30"
+                  className="flex items-center justify-center bg-black/60 px-3 py-2 text-white hover:bg-black/80 disabled:opacity-30 cursor-pointer disabled:cursor-default"
                   aria-label="Zoom out"
                 >
                   <ZoomOut className="h-4 w-4" />
                 </button>
               </div>
-            )}
-
-            {!isLoading && zoom === 1 && (
-              <p className="absolute bottom-10 left-1/2 -translate-x-1/2 pointer-events-none select-none whitespace-nowrap rounded-full bg-black/50 px-3 py-1 text-xs text-white shadow-[0_2px_8px_rgba(0,0,0,0.6)] md:bottom-8">
-                Double-click to zoom · scroll or pinch to zoom
-              </p>
             )}
           </Dialog.Content>
         </Dialog.Portal>

--- a/mvvm/src/components/containers/image-container.tsx
+++ b/mvvm/src/components/containers/image-container.tsx
@@ -4,7 +4,7 @@ import * as Dialog from "@radix-ui/react-dialog";
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden";
 import { useEffect, useRef, useState, useCallback } from "react";
 import Image from "next/image";
-import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { ChevronLeft, ChevronRight, X, ZoomIn, ZoomOut } from "lucide-react";
 
 interface ImageGalleryProps {
   images: ({ thumbnail: string; original: string } | undefined)[];
@@ -12,13 +12,13 @@ interface ImageGalleryProps {
 
 const MIN_ZOOM = 1;
 const MAX_ZOOM = 5;
+const ZOOM_STEP = 0.5;
 const DOUBLE_TAP_DELAY = 300;
 
 export default function ImageGallery({ images }: ImageGalleryProps) {
   const [selectedIndex, setSelectedIndex] = useState<number | null>(null);
   const [open, setOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(true);
-
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
 
@@ -28,6 +28,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
   const panAtDragStart = useRef({ x: 0, y: 0 });
   const lastTap = useRef(0);
   const lastPinchDist = useRef<number | null>(null);
+  const prevIndexRef = useRef<number | null>(null);
 
   const zoomRef = useRef(zoom);
   const panRef = useRef(pan);
@@ -38,6 +39,13 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
     setZoom(1);
     setPan({ x: 0, y: 0 });
   }, []);
+
+  useEffect(() => {
+    if (selectedIndex !== null && selectedIndex !== prevIndexRef.current) {
+      setIsLoading(true);
+      prevIndexRef.current = selectedIndex;
+    }
+  }, [selectedIndex]);
 
   const showPrev = useCallback(() => {
     setSelectedIndex((prev) => (prev !== null && prev > 0 ? prev - 1 : prev));
@@ -68,9 +76,17 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
     };
   }, []);
 
-  useEffect(() => {
-    if (selectedIndex !== null) setIsLoading(true);
-  }, [selectedIndex]);
+  const zoomIn = useCallback(() => {
+    setZoom((prev) => Math.min(MAX_ZOOM, parseFloat((prev + ZOOM_STEP).toFixed(1))));
+  }, []);
+
+  const zoomOut = useCallback(() => {
+    setZoom((prev) => {
+      const next = Math.max(MIN_ZOOM, parseFloat((prev - ZOOM_STEP).toFixed(1)));
+      if (next === MIN_ZOOM) setPan({ x: 0, y: 0 });
+      return next;
+    });
+  }, []);
 
   useEffect(() => {
     const handleKey = (e: KeyboardEvent) => {
@@ -89,7 +105,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
     const onWheel = (e: WheelEvent) => {
       e.preventDefault();
       setZoom((prev) => {
-        const next = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, prev - e.deltaY * 0.001));
+        const next = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, prev - e.deltaY * 0.005));
         if (next === MIN_ZOOM) setPan({ x: 0, y: 0 });
         return next;
       });
@@ -107,6 +123,10 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
         const dx = e.touches[0].clientX - e.touches[1].clientX;
         const dy = e.touches[0].clientY - e.touches[1].clientY;
         lastPinchDist.current = Math.hypot(dx, dy);
+        const midX = (e.touches[0].clientX + e.touches[1].clientX) / 2;
+        const midY = (e.touches[0].clientY + e.touches[1].clientY) / 2;
+        dragStart.current = { x: midX, y: midY };
+        panAtDragStart.current = panRef.current;
       } else if (e.touches.length === 1) {
         const now = Date.now();
         if (now - lastTap.current < DOUBLE_TAP_DELAY) {
@@ -116,11 +136,9 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
           return;
         }
         lastTap.current = now;
-        if (zoomRef.current > 1) {
-          isDragging.current = true;
-          dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
-          panAtDragStart.current = panRef.current;
-        }
+        isDragging.current = true;
+        dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+        panAtDragStart.current = panRef.current;
       }
     };
 
@@ -137,7 +155,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
           if (next <= MIN_ZOOM) setPan({ x: 0, y: 0 });
           return next;
         });
-      } else if (e.touches.length === 1 && isDragging.current) {
+      } else if (e.touches.length === 1 && isDragging.current && zoomRef.current > 1) {
         const dx = e.touches[0].clientX - dragStart.current.x;
         const dy = e.touches[0].clientY - dragStart.current.y;
         const clamped = clampPan(
@@ -152,6 +170,11 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
     const onTouchEnd = (e: TouchEvent) => {
       if (e.touches.length < 2) lastPinchDist.current = null;
       if (e.touches.length === 0) isDragging.current = false;
+      if (e.touches.length === 1) {
+        dragStart.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+        panAtDragStart.current = panRef.current;
+        isDragging.current = true;
+      }
     };
 
     el.addEventListener("touchstart", onTouchStart, { passive: false });
@@ -166,7 +189,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
 
   const onPointerDown = (e: React.PointerEvent) => {
     if (e.pointerType === "touch") return;
-    if (zoom <= 1) return;
+    if (zoomRef.current <= 1) return;
     isDragging.current = true;
     dragStart.current = { x: e.clientX, y: e.clientY };
     panAtDragStart.current = pan;
@@ -189,7 +212,10 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
   };
 
   const imageTransform = `scale(${zoom}) translate(${pan.x / zoom}px, ${pan.y / zoom}px)`;
-  const imageCursor = zoom > 1 ? (isDragging.current ? "grabbing" : "grab") : "default";
+  const imageCursor =
+    zoom > 1
+      ? isDragging.current ? "grabbing" : "grab"
+      : "zoom-in";
 
   return (
     <>
@@ -235,7 +261,7 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
             </Dialog.Title>
 
             <div className="absolute top-0 left-0 right-0 z-50 flex items-center justify-between px-4 py-3">
-              <p className="text-sm font-semibold text-white">
+              <p className="text-sm font-semibold text-white drop-shadow">
                 {selectedIndex !== null ? `${selectedIndex + 1} / ${images.length}` : ""}
               </p>
               <Dialog.Close
@@ -258,11 +284,10 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
                 <div className="h-[70vh] w-[85vw] max-w-5xl animate-pulse rounded-lg bg-gray-700" />
               )}
 
-              {images[selectedIndex!] && (
+              {selectedIndex !== null && images[selectedIndex] && (
                 <Image
-                  key={selectedIndex}
-                  src={images[selectedIndex!]?.original as string}
-                  alt={`Full image ${selectedIndex! + 1}`}
+                  src={images[selectedIndex]!.original}
+                  alt={`Full image ${selectedIndex + 1}`}
                   fill
                   loading="eager"
                   sizes="100vw"
@@ -299,9 +324,30 @@ export default function ImageGallery({ images }: ImageGalleryProps) {
               </button>
             )}
 
+            {!isLoading && (
+              <div className="absolute bottom-10 right-4 z-50 flex flex-col overflow-hidden rounded-lg shadow-lg md:bottom-8 md:right-6">
+                <button
+                  onClick={zoomIn}
+                  disabled={zoom >= MAX_ZOOM}
+                  className="flex items-center justify-center bg-black/60 px-3 py-2 text-white hover:bg-black/80 disabled:opacity-30 border-b border-white/20"
+                  aria-label="Zoom in"
+                >
+                  <ZoomIn className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={zoomOut}
+                  disabled={zoom <= MIN_ZOOM}
+                  className="flex items-center justify-center bg-black/60 px-3 py-2 text-white hover:bg-black/80 disabled:opacity-30"
+                  aria-label="Zoom out"
+                >
+                  <ZoomOut className="h-4 w-4" />
+                </button>
+              </div>
+            )}
+
             {!isLoading && zoom === 1 && (
-              <p className="absolute bottom-4 left-1/2 -translate-x-1/2 pointer-events-none select-none text-xs text-white/50">
-                Scroll or pinch to zoom · Double-tap to zoom in
+              <p className="absolute bottom-10 left-1/2 -translate-x-1/2 pointer-events-none select-none whitespace-nowrap rounded-full bg-black/50 px-3 py-1 text-xs text-white shadow-[0_2px_8px_rgba(0,0,0,0.6)] md:bottom-8">
+                Double-click to zoom · scroll or pinch to zoom
               </p>
             )}
           </Dialog.Content>


### PR DESCRIPTION
## Summary
Overhaul of the blog post image viewer with full-viewport display, zoom/pan support across desktop and mobile, and a precisely scoped cursor.

## Changes

### `mvvm/src/components/containers/image-container.tsx`

**Layout**
- Switched from fixed `width={400}` to `fill` + `object-contain` so landscape photos use the full available viewport on desktop instead of being capped at 400px
- Overlay background increased to `bg-black/90` for better contrast

**Zoom & Pan**
- Mouse wheel / trackpad pinch-to-zoom (1x–5x range)
- Single click on image toggles zoom in/out on desktop
- Double-tap to zoom in/out on mobile
- Pinch-to-zoom on touch devices
- Single-finger drag-to-pan on touch when zoomed in (works after pinch or double-tap)
- Mouse drag-to-pan when zoomed in
- Zoom buttons (ZoomIn/ZoomOut pill) in bottom-right corner
- Zoom and pan reset on image navigation and modal close
- `hasDragged` ref prevents drag release from triggering click zoom, and is reset on nav/close so click-to-zoom always works after navigation

**Cursor**
- `getContainRect()` computes the exact pixel bounds of the `object-contain` image using `naturalWidth`/`naturalHeight` and container dimensions
- Transparent overlay div positioned precisely over the visible image area — zoom/grab cursor only appears over actual photo pixels, not letterbox areas
- Overlay scales with zoom level so cursor boundary tracks the image at all zoom levels
- `onImageOverlayClick` checks `e.nativeEvent.pointerType` and ignores touch events — prevents the synthetic mouse click browsers fire after a tap from triggering single-click zoom on mobile

**Performance**
- Removed `key={selectedIndex}` — was force-remounting the image on every navigation, bypassing browser cache. Replaced with `prevIndexRef` tracking to only set `isLoading` when the index actually changes
- All gesture listeners attached once to `window` on mount with an empty dependency array, gated by `openRef` — eliminates timing issues where the effect ran before the dialog DOM was ready
- Touch listeners registered with `{ passive: false }` so `preventDefault` works correctly

**Mobile**
- Touch zoom: double-tap (not single-tap)
- Touch pan: single finger after pinch or double-tap
- Pinch-to-zoom with seamless transition to single-finger pan when one finger lifts